### PR TITLE
Fix duplicate runtime export in worker-proxy route

### DIFF
--- a/apps/web/src/app/api/worker-proxy/[...path]/route.ts
+++ b/apps/web/src/app/api/worker-proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 const WORKER_URL = process.env.WORKER_URL || 'http://localhost:8787';
 


### PR DESCRIPTION
- Add missing 'export const dynamic = force-dynamic' declaration
- Resolves production build failure with duplicate runtime exports
- Production build now succeeds locally